### PR TITLE
feat: Add mkdocs-header-dropdown plugin

### DIFF
--- a/requirements-plugins.txt
+++ b/requirements-plugins.txt
@@ -1,6 +1,7 @@
 mkdocs-awesome-nav==3.2.0
 mkdocs-git-revision-date-localized-plugin==1.5.0
 mkdocs-glightbox==0.5.2
+mkdocs-header-dropdown==0.1.0
 mkdocs-merge==0.11.0
 mkdocs-minify-plugin==0.8.0
 mkdocs-panzoom-plugin==0.4.2


### PR DESCRIPTION
Add mkdocs-header-dropdown==0.1.0 to the Docker image.

This plugin adds configurable dropdown menus to the Material theme
header, allowing for easy cross-documentation navigation.

PyPI package: https://pypi.org/project/mkdocs-header-dropdown/
