### PR TITLE
Add dependency-aware release versioning

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,35 +1,26 @@
-name-template: '$RESOLVED_VERSION 🌈'
-tag-template: '$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
-    labels:
-      - 'feature'
-      - 'enhancement'
+    when:
+      labels:
+        - 'feature'
+        - 'enhancement'
   - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
+    when:
+      labels:
+        - 'fix'
+        - 'bugfix'
+        - 'bug'
   - title: '🧰 Maintenance'
-    labels:
-      - 'chore'
-      - 'dependencies'
-      - 'marketing'
+    when:
+      labels:
+        - 'chore'
+        - 'dependencies'
+        - 'marketing'
+  - type: 'pre-exclude'
+    when:
+      label: 'skip-changelog'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-exclude-labels:
-  - 'skip-changelog'
 autolabeler:
   - label: 'documentation'
     files:
@@ -49,13 +40,3 @@ autolabeler:
 template: |
   ## Changes
   $CHANGES
-
-  ## Usage
-  To pull the image run
-  ```bash
-  docker pull ghcr.io/cms-cat/mkdocs-material:$RESOLVED_VERSION
-  ```
-  Using the image as a base image in your Dockerfile
-  ```
-  FROM ghcr.io/cms-cat/mkdocs-material:$RESOLVED_VERSION
-  ```

--- a/.github/scripts/resolve_release_version.py
+++ b/.github/scripts/resolve_release_version.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Resolve the next repository release version from the core package pin."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+
+COMPONENT = r"(?:0|[1-9][0-9]*)"
+CORE_REQUIREMENT = re.compile(
+    rf"^mkdocs[-_]material\s*==\s*({COMPONENT})\.({COMPONENT})\.({COMPONENT})$",
+    re.IGNORECASE,
+)
+CORE_REFERENCE = re.compile(r"^mkdocs[-_]material\b", re.IGNORECASE)
+RELEASE_TAG = re.compile(
+    rf"^({COMPONENT})\.({COMPONENT})\.({COMPONENT})(?:\.({COMPONENT}))?$"
+)
+
+CoreVersion = tuple[int, int, int]
+ReleaseVersion = tuple[int, int, int, int]
+
+
+class VersionResolutionError(ValueError):
+    """Raised when release version inputs are invalid or inconsistent."""
+
+
+def read_core_version(requirements_path: Path) -> CoreVersion:
+    """Read the single, exact mkdocs-material pin from a requirements file."""
+
+    requirement_lines = []
+    for line in requirements_path.read_text(encoding="utf-8").splitlines():
+        requirement = line.partition("#")[0].strip()
+        if requirement and CORE_REFERENCE.match(requirement):
+            requirement_lines.append(requirement)
+
+    if not requirement_lines:
+        raise VersionResolutionError(
+            f"{requirements_path} does not contain an mkdocs-material pin"
+        )
+    if len(requirement_lines) > 1:
+        raise VersionResolutionError(
+            f"{requirements_path} contains multiple mkdocs-material requirements"
+        )
+
+    match = CORE_REQUIREMENT.fullmatch(requirement_lines[0])
+    if not match:
+        raise VersionResolutionError(
+            "mkdocs-material must be pinned as mkdocs-material==X.Y.Z"
+        )
+
+    major, minor, patch = match.groups()
+    return int(major), int(minor), int(patch)
+
+
+def parse_release_tag(tag: str) -> ReleaseVersion | None:
+    """Parse a repository release tag, ignoring unrelated tag formats."""
+
+    match = RELEASE_TAG.fullmatch(tag.strip())
+    if not match:
+        return None
+
+    major, minor, patch, subpatch = match.groups()
+    return int(major), int(minor), int(patch), int(subpatch or 0)
+
+
+def format_core_version(version: CoreVersion) -> str:
+    return ".".join(str(component) for component in version)
+
+
+def resolve_release_version(
+    core_version: CoreVersion, published_tags: Iterable[str]
+) -> str:
+    """Resolve the next release from the core pin and published stable tags."""
+
+    published_versions = [
+        version
+        for tag in published_tags
+        if (version := parse_release_tag(tag)) is not None
+    ]
+    formatted_core = format_core_version(core_version)
+    if not published_versions:
+        return formatted_core
+
+    latest_release = max(published_versions)
+    latest_core = latest_release[:3]
+    if core_version < latest_core:
+        raise VersionResolutionError(
+            f"mkdocs-material {formatted_core} is older than the latest published "
+            f"release base {format_core_version(latest_core)}"
+        )
+    if core_version > latest_core:
+        return formatted_core
+
+    return f"{formatted_core}.{latest_release[3] + 1}"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--requirements",
+        type=Path,
+        default=Path("requirements.txt"),
+        help="requirements file containing the mkdocs-material pin",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        core_version = read_core_version(args.requirements)
+        release_version = resolve_release_version(core_version, sys.stdin)
+    except (OSError, VersionResolutionError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"version={release_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_resolve_release_version.py
+++ b/.github/scripts/test_resolve_release_version.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from resolve_release_version import (
+    VersionResolutionError,
+    main,
+    read_core_version,
+    resolve_release_version,
+)
+
+
+class ResolveReleaseVersionTests(unittest.TestCase):
+    def test_uses_core_version_when_no_release_exists(self) -> None:
+        self.assertEqual(resolve_release_version((9, 7, 7), []), "9.7.7")
+
+    def test_uses_newer_core_version_without_subpatch(self) -> None:
+        self.assertEqual(
+            resolve_release_version((9, 7, 7), ["9.7.6.3"]), "9.7.7"
+        )
+
+    def test_starts_subpatch_series_for_unchanged_core(self) -> None:
+        self.assertEqual(
+            resolve_release_version((9, 7, 7), ["9.7.7"]), "9.7.7.1"
+        )
+
+    def test_increments_existing_subpatch(self) -> None:
+        self.assertEqual(
+            resolve_release_version((9, 7, 7), ["9.7.7", "9.7.7.1"]),
+            "9.7.7.2",
+        )
+
+    def test_repeated_runs_coalesce_while_draft_is_unpublished(self) -> None:
+        published_tags = ["9.7.7"]
+        first_run = resolve_release_version((9, 7, 7), published_tags)
+        second_run = resolve_release_version((9, 7, 7), published_tags)
+        self.assertEqual(first_run, "9.7.7.1")
+        self.assertEqual(second_run, first_run)
+
+    def test_selects_highest_release_and_ignores_unrelated_tags(self) -> None:
+        tags = ["not-a-package-release", "9.7.7.2", "9.7.6.20", "9.7.7.1"]
+        self.assertEqual(resolve_release_version((9, 7, 7), tags), "9.7.7.3")
+
+    def test_rejects_core_version_regression(self) -> None:
+        with self.assertRaisesRegex(VersionResolutionError, "older than"):
+            resolve_release_version((9, 7, 7), ["9.7.8"])
+
+
+class ReadCoreVersionTests(unittest.TestCase):
+    def read(self, contents: str) -> tuple[int, int, int]:
+        with tempfile.TemporaryDirectory() as directory:
+            requirements = Path(directory) / "requirements.txt"
+            requirements.write_text(contents, encoding="utf-8")
+            return read_core_version(requirements)
+
+    def test_reads_exact_pin(self) -> None:
+        self.assertEqual(self.read("mkdocs-material==9.7.7\n"), (9, 7, 7))
+
+    def test_rejects_missing_pin(self) -> None:
+        with self.assertRaisesRegex(VersionResolutionError, "does not contain"):
+            self.read("mkdocs==1.6.1\n")
+
+    def test_rejects_unsupported_version(self) -> None:
+        with self.assertRaisesRegex(VersionResolutionError, "X.Y.Z"):
+            self.read("mkdocs-material==9.7.7rc1\n")
+
+    def test_rejects_multiple_requirements(self) -> None:
+        with self.assertRaisesRegex(VersionResolutionError, "multiple"):
+            self.read("mkdocs-material==9.7.6\nmkdocs_material==9.7.7\n")
+
+
+class CommandLineTests(unittest.TestCase):
+    def test_emits_github_actions_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            requirements = Path(directory) / "requirements.txt"
+            requirements.write_text("mkdocs-material==9.7.7\n", encoding="utf-8")
+            output = io.StringIO()
+            with patch("sys.stdin", io.StringIO("9.7.7\n")), redirect_stdout(output):
+                result = main(["--requirements", str(requirements)])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(output.getvalue(), "version=9.7.7.1\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,14 +4,61 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'requirements.txt'
+      - 'requirements-plugins.txt'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-drafter
+  cancel-in-progress: false
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v7
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Resolve release version
+        id: release_version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          releases_api="repos/${GITHUB_REPOSITORY}/releases?per_page=100"
+          stable_draft_count="$(
+            gh api --paginate "${releases_api}" \
+              --jq '.[] | select(.draft == true and .prerelease == false) | .id' |
+              wc -l |
+              tr -d '[:space:]'
+          )"
+          if (( stable_draft_count > 1 )); then
+            echo "::error::Found ${stable_draft_count} stable draft releases; expected at most one."
+            exit 1
+          fi
+
+          gh api --paginate "${releases_api}" \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' |
+            python3 .github/scripts/resolve_release_version.py \
+              --requirements requirements.txt >> "${GITHUB_OUTPUT}"
+
+      - name: Update release draft
+        uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: '${{ steps.release_version.outputs.version }} 🌈'
+          tag: '${{ steps.release_version.outputs.version }}'
+          commitish: '${{ github.sha }}'
+          footer: |
+            ## Usage
+            To pull the image run
+            ```bash
+            docker pull ghcr.io/cms-cat/mkdocs-material:${{ steps.release_version.outputs.version }}
+            ```
+            Using the image as a base image in your Dockerfile
+            ```
+            FROM ghcr.io/cms-cat/mkdocs-material:${{ steps.release_version.outputs.version }}
+            ```


### PR DESCRIPTION
## Summary

- derive the repository release base from the pinned `mkdocs-material==X.Y.Z` version
- increment a fourth version component for plugin-only releases
- preserve exact four-component tags by passing computed names and tags directly to Release Drafter
- migrate the Release Drafter configuration away from deprecated category and resolver fields
- scope draft updates to Python requirements changes and serialize concurrent runs

## Why

Release Drafter v7 warns about the legacy category, exclusion, and version-resolver fields. Its SemVer resolver also coerces tags such as `9.7.7.1` to three components, so it cannot natively express this repository's existing sub-patch release convention.

The new standard-library resolver compares the current core pin with all published stable package tags. Core updates draft the exact upstream version, while unchanged core versions advance the fourth component. Unpublished plugin changes continue to coalesce into the same draft.

## Impact

Releases remain drafts and are still published manually. Publishing continues to trigger the existing multi-architecture image workflow. Non-requirements pushes no longer update the release draft, though their changes can appear when the next dependency release is drafted.

## Validation

- `python3 -m unittest discover -s .github/scripts -p 'test_*.py'` — 12 tests pass
- YAML parsing and workflow/config semantic assertions pass
- live resolution against published repository tags returns `version=9.7.7`
- the current stable draft count is one
- `git diff --check` passes
